### PR TITLE
Fix automatic restoration of associated objects

### DIFF
--- a/django_softdelete/models.py
+++ b/django_softdelete/models.py
@@ -243,8 +243,10 @@ class SoftDeleteModel(models.Model):
         if on_delete == models.CASCADE:
             if strict:
                 kwargs['strict'] = strict
-            related_object.delete(transaction_id=transaction_id, *args, **kwargs)
-
+            if isinstance(related_object, SoftDeleteModel):
+                related_object.delete(transaction_id=transaction_id, *args, **kwargs)
+            else:
+                related_object.delete(*args, **kwargs)
         elif on_delete == models.SET_NULL:
             setattr(related_object, field.remote_field.name, None)
             related_object.save()


### PR DESCRIPTION
I propose fix for the problem described in [this issue](https://github.com/san4ezy/django_softdelete/issues/35). It is important to save an identifier (in this case uuid4) for each soft deletion transaction. That id is propagated to all associated objects and stored when they are soft deleted. When restoration is started, all objects that match that id, will be restored. With this approach, objects that are deleted in another transaction, won't be restored.