### PR TITLE
Add strict default argument for querysets

### DIFF
--- a/django_softdelete/managers.py
+++ b/django_softdelete/managers.py
@@ -17,14 +17,14 @@ class SoftDeleteQuerySet(models.query.QuerySet):
     - hard_delete(): Hard deletes all objects in the QuerySet.
 
     """
-    def delete(self):
+    def delete(self, strict: bool = False):
         """
         Delete all objects stored in the class.
 
         :return: None
         """
         for obj in self.all():
-            obj.delete()
+            obj.delete(strict=strict)
         return
 
     def hard_delete(self):
@@ -42,7 +42,7 @@ class DeletedQuerySet(models.query.QuerySet):
 
     restore(*args, **kwargs) - Restore deleted objects based on the given filter arguments.
     """
-    def restore(self, *args, **kwargs):
+    def restore(self, strict: bool = True, *args, **kwargs):
         """
         Restore items from the trash.
 
@@ -52,7 +52,7 @@ class DeletedQuerySet(models.query.QuerySet):
         """
         qs = self.filter(*args, **kwargs)
         for obj in qs:
-            obj.restore()
+            obj.restore(strict=strict)
         return
 
 


### PR DESCRIPTION
@san4ezy Thanks for approving my previous PR. 
I find it useful to have it on `SoftDeleteQuerySet` and `DeletedQuerySet` querysets. Since you can delete entity with this flag directly, it would probably make sense to be able to do it in bulk. I would like to hear your thought about this.
