### PR TITLE
chore: add `hard_delete` method to `DeletedQuerySet`

### DIFF
--- a/django_softdelete/managers.py
+++ b/django_softdelete/managers.py
@@ -44,6 +44,12 @@ class DeletedQuerySet(models.query.QuerySet):
             obj.restore(strict=strict)
         return
 
+    def hard_delete(self):
+        """
+        Hard delete the objects permanently.
+        """
+        return super().delete()
+
 
 class SoftDeleteManager(models.Manager):
     """


### PR DESCRIPTION
Fix for https://github.com/san4ezy/django_softdelete/issues/47

Now the Django Admin pages can hard-delete selected objects without running into the error:

```text
AttributeError: 'DeletedQuerySet' object has no attribute 'hard_delete'
```