### PR TITLE
Update setup.cfg metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
```
* Getting build dependencies for wheel...
/usr/local/lib/python3.11/site-packages/setuptools/dist.py:771:
UserWarning: Usage of dash-separated 'description-file' will not
be supported in future versions.

Please use the underscore name 'description_file' instead
```