### PR TITLE
fix: stop triggering post_delete signal from soft delete operation

### DIFF
--- a/django_softdelete/models.py
+++ b/django_softdelete/models.py
@@ -152,9 +152,6 @@ class SoftDeleteModel(models.Model):
             post_soft_delete.send(
                 sender=self.__class__, instance=self, using=using,
             )
-            post_delete.send(
-                sender=self.__class__, instance=self, using=using,
-            )
 
     def restore(self, strict: bool = True, transaction_id: str = None, *args, **kwargs):
         """Restores a deleted object by setting the deleted_at field to None.


### PR DESCRIPTION
This PR removes the redundant emission of the `post_delete` signal in the `SoftDeleteModel` class.

The signal was being sent immediately after the `post_soft_delete` signal. The `post_delete` signal is already being triggered upon `delete()` from the base Django `Model` instance. This makes it impossible to separate `post_delete` (hard delete) and `post_soft_delete` (soft delete) signal handlers.

Applications that rely on `post_delete` signals would perform unnecessary or incorrect operations for every soft-delete operation.