### PR TITLE
Fix bulk hard delete operation in Django admin

### DIFF
--- a/django_softdelete/admin.py
+++ b/django_softdelete/admin.py
@@ -4,7 +4,8 @@ from django_softdelete.filters import SoftDeleteFilter
 
 @admin.action(description="Hard delete selected items")
 def hard_delete_selected_items(modeladmin, request, queryset):
-    queryset.hard_delete()
+    for obj in queryset:
+        obj.hard_delete()
 
 @admin.action(description="Restore selected items")
 def restore_selected_items(modeladmin, request, queryset):


### PR DESCRIPTION
## Summary
This PR modifies the `hard_delete_selected_items` admin action to process deletions one at a time instead of using bulk deletion. This change ensures proper signal handling and cascading deletions for each object.

## Files Changed
- `django_softdelete/admin.py`: Modified the `hard_delete_selected_items` function to iterate through queryset objects individually

## Code Changes
The change replaces the bulk deletion approach with individual object processing:
```python
# Before
queryset.hard_delete()

# After
for obj in queryset:
    obj.hard_delete()
```

## Reason for Changes
The bulk deletion approach (`queryset.hard_delete()`) bypasses individual object deletion signals and may not properly handle cascading deletions in complex object relationships. By processing each object individually, we ensure:

1. All pre_delete and post_delete signals are properly triggered for each object
2. Cascading deletions are handled correctly
3. Custom deletion logic in model's `hard_delete()` method is respected for each object

## Impact of Changes
- **Positive**: More reliable deletion process that respects all Django signals and cascading relationships
- **Negative**: Slightly slower performance when deleting multiple objects, as each deletion is processed separately

## Test Plan
1. Select multiple objects with relationships in Django admin
2. Trigger hard delete action
3. Verify that:
   - All selected objects are properly deleted
   - Related objects are handled according to their on_delete specifications
   - All relevant signals are triggered for each deleted object

## Additional Notes
While this change may impact performance when deleting large numbers of objects, the trade-off for reliability and proper signal handling is worth it. If bulk performance becomes a concern, we could consider adding a separate bulk deletion action that explicitly warns about bypassing individual object processing.
kayv