### PR TITLE
Optimize soft delete/restore queryset + cascade paths to eliminate N+1 queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed:
+
+- Optimize `SoftDeleteQuerySet.delete()` to use a bulk soft-delete path, reducing N+1 query behavior and assigning a single `transaction_id` across the queryset operation.
+- Optimize one-to-many `CASCADE` soft-delete paths to batch soft-delete related `SoftDeleteModel` rows instead of deleting each related row one-by-one.
+- Optimize `DeletedQuerySet.restore()` to use a bulk restore path, reducing N+1 query behavior and keeping transaction-scoped restore semantics.
+- Add regression tests for queryset/cascade delete/restore query scaling and bulk delete `transaction_id` consistency.
+
 ## [1.0.23] - 2026-02-21
 
 ### Fixed:

--- a/django_softdelete/managers.py
+++ b/django_softdelete/managers.py
@@ -18,6 +18,15 @@ class SoftDeleteQuerySet(models.query.QuerySet):
         Soft-deletes the objects in the queryset, aggregates the delete counts,
         and returns the standard (count, dict_of_counts) tuple.
         """
+        bulk_soft_delete = getattr(self.model, "_soft_delete_queryset", None)
+        if callable(bulk_soft_delete):
+            return bulk_soft_delete(
+                self,
+                strict=strict,
+                transaction_id=transaction_id,
+                *args, **kwargs
+            )
+
         total_count = 0
         total_counts_dict = defaultdict(int)
 
@@ -52,7 +61,12 @@ class DeletedQuerySet(models.query.QuerySet):
 
     restore(*args, **kwargs) - Restore deleted objects based on the given filter arguments.
     """
-    def restore(self, strict: bool = True, *args, **kwargs):
+    def restore(
+            self,
+            strict: bool = True,
+            transaction_id: str = None,
+            *args, **kwargs
+    ):
         """
         Restore items from the trash.
 
@@ -61,8 +75,20 @@ class DeletedQuerySet(models.query.QuerySet):
         :return: None.
         """
         qs = self.filter(*args, **kwargs)
+        bulk_restore = getattr(self.model, "_restore_queryset", None)
+        if callable(bulk_restore):
+            bulk_restore(
+                qs,
+                strict=strict,
+                transaction_id=transaction_id,
+            )
+            return
+
         for obj in qs:
-            obj.restore(strict=strict)
+            obj.restore(
+                strict=strict,
+                transaction_id=transaction_id,
+            )
         return
     restore.alters_data = True
 
@@ -91,7 +117,12 @@ class GlobalQuerySet(models.query.QuerySet):
         return
     delete.alters_data = True
 
-    def restore(self, strict: bool = True, *args, **kwargs):
+    def restore(
+            self,
+            strict: bool = True,
+            transaction_id: str = None,
+            *args, **kwargs
+    ):
         """
         Restore items from the trash.
 
@@ -101,8 +132,20 @@ class GlobalQuerySet(models.query.QuerySet):
         :return: None.
         """
         qs = self.filter(*args, **kwargs)
+        bulk_restore = getattr(self.model, "_restore_queryset", None)
+        if callable(bulk_restore):
+            bulk_restore(
+                qs,
+                strict=strict,
+                transaction_id=transaction_id,
+            )
+            return
+
         for obj in qs:
-            obj.restore(strict=strict)
+            obj.restore(
+                strict=strict,
+                transaction_id=transaction_id,
+            )
         return
     restore.alters_data = True
 

--- a/django_softdelete/models.py
+++ b/django_softdelete/models.py
@@ -150,7 +150,9 @@ class SoftDeleteModel(models.Model):
                 #     print("M2M reverse", field.name, field.remote_field)  # field.remote_field?
 
                 elif field.one_to_many:
-                    cascade_count, cascade_counts_dict = self.__delete_related_one_to_many(field, strict, transaction_id, *args, **kwargs)
+                    cascade_count, cascade_counts_dict = self.__delete_related_one_to_many(
+                        field, strict, transaction_id, *args, **kwargs
+                    )
 
                 else:
                     continue
@@ -178,7 +180,330 @@ class SoftDeleteModel(models.Model):
         return total_count, deleted_counts_dict
     delete.alters_data = True
 
-    def restore(self, strict: bool = True, transaction_id: str = None, *args, **kwargs):
+    @classmethod
+    def _iterative_soft_delete_queryset(
+            cls,
+            queryset,
+            strict: bool = False,
+            transaction_id: str = None,
+            using=None,
+            *args, **kwargs,
+    ):
+        total_count = 0
+        total_counts_dict = defaultdict(int)
+
+        for obj in queryset.iterator():
+            count, counts_dict = obj.delete(
+                strict=strict,
+                transaction_id=transaction_id,
+                using=using,
+                *args, **kwargs
+            )
+            total_count += count
+            for model_name, deleted_count in counts_dict.items():
+                total_counts_dict[model_name] += deleted_count
+
+        return total_count, dict(total_counts_dict)
+
+    @classmethod
+    def _soft_delete_queryset(
+            cls,
+            queryset,
+            strict: bool = False,
+            transaction_id: str = None,
+            using=None,
+            _visited=None,
+            *args, **kwargs,
+    ):
+        transaction_id = uuid.uuid4() if not transaction_id else transaction_id
+        now = timezone.now()
+
+        queryset = queryset.filter(deleted_at__isnull=True)
+        parent_ids = list(queryset.values_list("pk", flat=True))
+        if _visited is None:
+            _visited = set()
+        node_ids = [
+            obj_id for obj_id in parent_ids if (cls._meta.label, obj_id) not in _visited
+        ]
+        for obj_id in node_ids:
+            _visited.add((cls._meta.label, obj_id))
+        parent_ids = node_ids
+        if not parent_ids:
+            return 0, {}
+        queryset = queryset.filter(pk__in=parent_ids)
+
+        for field in cls._meta.get_fields():
+            if isinstance(field, GenericRelation):
+                continue
+            if not field.one_to_one:
+                continue
+            if hasattr(field, "attname"):
+                if queryset.filter(**{f"{field.attname}__isnull": False}).exists():
+                    return cls._iterative_soft_delete_queryset(
+                        queryset,
+                        strict=strict,
+                        transaction_id=transaction_id,
+                        using=using,
+                        *args, **kwargs,
+                    )
+
+        supported_on_delete = {
+            models.CASCADE,
+            models.PROTECT,
+            models.RESTRICT,
+            models.SET_NULL,
+            models.SET_DEFAULT,
+            models.DO_NOTHING,
+        }
+        for field in cls._meta.get_fields():
+            if isinstance(field, GenericRelation) or not field.one_to_many:
+                continue
+            if hasattr(field, 'on_delete'):
+                on_delete = field.on_delete
+            elif hasattr(field, 'remote_field') and hasattr(field.remote_field, 'on_delete'):
+                on_delete = field.remote_field.on_delete
+            else:
+                continue
+            if on_delete in supported_on_delete:
+                continue
+            related_queryset = field.related_model.objects.filter(
+                **{f"{field.remote_field.name}__in": parent_ids}
+            )
+            if related_queryset.exists():
+                return cls._iterative_soft_delete_queryset(
+                    queryset,
+                    strict=strict,
+                    transaction_id=transaction_id,
+                    using=using,
+                    *args, **kwargs,
+                )
+
+        total_count = 0
+        deleted_counts_dict = defaultdict(int)
+        objects_for_signals = list(queryset)
+
+        with transaction.atomic():
+            for obj in objects_for_signals:
+                pre_delete.send(sender=cls, instance=obj, using=using)
+
+            for field in cls._meta.get_fields():
+                if isinstance(field, GenericRelation):
+                    continue
+
+                RelatedModel = field.related_model
+                if not RelatedModel:
+                    continue
+
+                if strict and not issubclass(RelatedModel, SoftDeleteModel):
+                    raise SoftDeleteException(
+                        f"{RelatedModel.__name__} is not a subclass of SoftDeleteModel."
+                    )
+
+                if not field.one_to_many:
+                    continue
+
+                if hasattr(field, 'on_delete'):
+                    on_delete = field.on_delete
+                elif hasattr(field, 'remote_field') and hasattr(field.remote_field, 'on_delete'):
+                    on_delete = field.remote_field.on_delete
+                else:
+                    continue
+
+                related_filter = {f"{field.remote_field.name}__in": parent_ids}
+                related_queryset = RelatedModel.objects.filter(**related_filter)
+
+                if on_delete == models.CASCADE:
+                    if issubclass(RelatedModel, SoftDeleteModel):
+                        cascade_count, cascade_counts_dict = RelatedModel._soft_delete_queryset(
+                            related_queryset,
+                            strict=strict,
+                            transaction_id=transaction_id,
+                            using=using,
+                            _visited=_visited,
+                            *args, **kwargs,
+                        )
+                    else:
+                        hard_kwargs = dict(kwargs)
+                        cascade_count, cascade_counts_dict = related_queryset.delete(
+                            *args, **hard_kwargs
+                        )
+                elif on_delete == models.PROTECT:
+                    if related_queryset.exists():
+                        raise ProtectedError(
+                            f"Cannot delete queryset of {cls.__name__} because related objects "
+                            f"of {RelatedModel.__name__} are protected",
+                            list(related_queryset),
+                        )
+                    cascade_count, cascade_counts_dict = 0, {}
+                elif on_delete == models.RESTRICT:
+                    if related_queryset.exists():
+                        raise ProtectedError(
+                            f"Cannot delete queryset of {cls.__name__} because related objects "
+                            f"of {RelatedModel.__name__} are restricted",
+                            list(related_queryset),
+                        )
+                    cascade_count, cascade_counts_dict = 0, {}
+                elif on_delete == models.SET_NULL:
+                    related_queryset.update(**{field.remote_field.name: None})
+                    cascade_count, cascade_counts_dict = 0, {}
+                elif on_delete == models.SET_DEFAULT:
+                    default_value = field.remote_field.get_default()
+                    related_queryset.update(**{field.remote_field.name: default_value})
+                    cascade_count, cascade_counts_dict = 0, {}
+                elif on_delete == models.DO_NOTHING:
+                    cascade_count, cascade_counts_dict = 0, {}
+                else:
+                    cascade_count, cascade_counts_dict = 0, {}
+
+                total_count += cascade_count
+                for model_name, count in cascade_counts_dict.items():
+                    deleted_counts_dict[model_name] += count
+
+            updated_count = cls.global_objects.filter(
+                pk__in=parent_ids, deleted_at__isnull=True
+            ).update(
+                deleted_at=now,
+                restored_at=None,
+                transaction_id=transaction_id,
+            )
+
+            total_count += updated_count
+            deleted_counts_dict[cls._meta.label] += updated_count
+
+            for obj in objects_for_signals:
+                obj.deleted_at = now
+                obj.restored_at = None
+                obj.transaction_id = transaction_id
+                post_soft_delete.send(sender=cls, instance=obj, using=using)
+
+        return total_count, dict(deleted_counts_dict)
+
+    @classmethod
+    def _iterative_restore_queryset(
+            cls,
+            queryset,
+            strict: bool = True,
+            transaction_id: str = None,
+            *args, **kwargs,
+    ):
+        for obj in queryset.iterator():
+            obj.restore(
+                strict=strict,
+                transaction_id=transaction_id,
+                *args, **kwargs
+            )
+        return
+
+    @classmethod
+    def _restore_queryset(
+            cls,
+            queryset,
+            strict: bool = True,
+            transaction_id: str = None,
+            using=None,
+            _visited=None,
+            *args, **kwargs,
+    ):
+        queryset = queryset.filter(deleted_at__isnull=False)
+        parent_rows = list(queryset.values_list("pk", "transaction_id"))
+        if not parent_rows:
+            return
+
+        if _visited is None:
+            _visited = set()
+
+        parent_rows = [
+            row for row in parent_rows if (cls._meta.label, row[0]) not in _visited
+        ]
+        for pk, _ in parent_rows:
+            _visited.add((cls._meta.label, pk))
+
+        if not parent_rows:
+            return
+
+        parent_ids = [pk for pk, _ in parent_rows]
+        queryset = queryset.filter(pk__in=parent_ids)
+
+        if transaction_id is None:
+            tx_values = {tx for _, tx in parent_rows}
+            if len(tx_values) != 1:
+                return cls._iterative_restore_queryset(
+                    queryset,
+                    strict=strict,
+                    *args, **kwargs,
+                )
+            transaction_id = tx_values.pop()
+
+        for field in cls._meta.get_fields():
+            if isinstance(field, GenericRelation):
+                continue
+            if not field.one_to_one:
+                continue
+            if hasattr(field, "attname"):
+                if queryset.filter(**{f"{field.attname}__isnull": False}).exists():
+                    return cls._iterative_restore_queryset(
+                        queryset,
+                        strict=strict,
+                        transaction_id=transaction_id,
+                        *args, **kwargs,
+                    )
+
+        objects_for_signals = list(queryset)
+
+        with transaction.atomic():
+            for field in cls._meta.get_fields():
+                if isinstance(field, GenericRelation):
+                    continue
+
+                RelatedModel = field.related_model
+                if not RelatedModel:
+                    continue
+
+                if strict and not issubclass(RelatedModel, SoftDeleteModel):
+                    raise SoftDeleteException(
+                        f"{RelatedModel.__name__} is not a subclass of SoftDeleteModel."
+                    )
+
+                if not field.one_to_many or not issubclass(RelatedModel, SoftDeleteModel):
+                    continue
+
+                related_filter = {
+                    f"{field.remote_field.name}__in": parent_ids,
+                    "transaction_id": transaction_id,
+                }
+                RelatedModel._restore_queryset(
+                    RelatedModel.deleted_objects.filter(**related_filter),
+                    strict=strict,
+                    transaction_id=transaction_id,
+                    using=using,
+                    _visited=_visited,
+                    *args, **kwargs,
+                )
+
+            now = timezone.now()
+            cls.deleted_objects.filter(pk__in=parent_ids).update(
+                deleted_at=None,
+                restored_at=now,
+                transaction_id=None,
+            )
+
+            for obj in objects_for_signals:
+                obj.deleted_at = None
+                obj.restored_at = now
+                obj.transaction_id = None
+                post_restore.send(
+                    sender=cls,
+                    instance=obj,
+                    transaction_id=transaction_id,
+                )
+        return
+
+    def restore(
+            self,
+            strict: bool = True,
+            transaction_id: str = None,
+            *args, **kwargs
+    ):
         """Restores a deleted object by setting the deleted_at field to None.
 
         :param strict: A boolean indicating whether to perform strict restoration.
@@ -211,7 +536,9 @@ class SoftDeleteModel(models.Model):
                     )
 
                 if field.one_to_one:
-                    self.__restore_related_one_to_one(field, strict, transaction_id, *args, **kwargs)
+                    self.__restore_related_one_to_one(
+                        field, strict, transaction_id, *args, **kwargs
+                    )
 
                 # elif field.many_to_many:
                 #     # M2M must not be restored
@@ -231,12 +558,18 @@ class SoftDeleteModel(models.Model):
             self.save(
                 update_fields=['deleted_at', 'restored_at', 'transaction_id', ]
             )
-            post_restore.send(sender=self.__class__, instance=self, transaction_id=transaction_id)
+            post_restore.send(
+                sender=self.__class__,
+                instance=self,
+                transaction_id=transaction_id,
+            )
     restore.alters_data = True
 
     # PRIVATE SECTION
 
-    def __delete_related_object(self, field, related_object, strict, transaction_id, *args, **kwargs):
+    def __delete_related_object(
+            self, field, related_object, strict, transaction_id, *args, **kwargs
+    ):
         """
         :param field: The field that defines the relationship between the current object and the related object.
         :param related_object: The related object that needs to be deleted.
@@ -283,7 +616,10 @@ class SoftDeleteModel(models.Model):
             if isinstance(related_object, SoftDeleteModel):
                 if strict:
                     kwargs['strict'] = strict
-                deleted_counter = related_object.delete(transaction_id=transaction_id, *args, **kwargs)
+                deleted_counter = related_object.delete(
+                    transaction_id=transaction_id,
+                    *args, **kwargs
+                )
             else:
                 kwargs.pop("o2o_model", None)
                 deleted_counter = related_object.delete(*args, **kwargs)
@@ -345,7 +681,9 @@ class SoftDeleteModel(models.Model):
 
         return deleted_counter
 
-    def __restore_related_object(self, field, related_object, strict, transaction_id, *args, **kwargs):
+    def __restore_related_object(
+            self, field, related_object, strict, transaction_id, *args, **kwargs
+    ):
         """
         Restores a related object and saves it if it has a valid primary key.
 
@@ -365,14 +703,20 @@ class SoftDeleteModel(models.Model):
         :rtype: None
         """
         if related_object.is_deleted:
-            related_object.restore(strict=strict, transaction_id=transaction_id, *args, **kwargs)
+            related_object.restore(
+                strict=strict,
+                transaction_id=transaction_id,
+                *args, **kwargs
+            )
             try:
                 if related_object.pk is not None:
                     related_object.save()
             except AttributeError:
                 pass
 
-    def __delete_related_one_to_one(self, field, strict, transaction_id, *args, **kwargs):
+    def __delete_related_one_to_one(
+            self, field, strict, transaction_id, *args, **kwargs
+    ):
         """
         Delete related one-to-one object.
 
@@ -411,7 +755,9 @@ class SoftDeleteModel(models.Model):
 
         return deleted_counter
 
-    def __delete_related_one_to_many(self, field, strict, transaction_id, *args, **kwargs):
+    def __delete_related_one_to_many(
+            self, field, strict, transaction_id, *args, **kwargs
+    ):
         """
         Delete all related objects in a one-to-many relationship.
 
@@ -428,6 +774,24 @@ class SoftDeleteModel(models.Model):
         total_counts_dict = defaultdict(int)
 
         related_objects = getattr(self, field.get_accessor_name()).all()
+        if hasattr(field, 'on_delete'):
+            on_delete = field.on_delete
+        elif hasattr(field, 'remote_field') and hasattr(field.remote_field, 'on_delete'):
+            on_delete = field.remote_field.on_delete
+        else:
+            on_delete = None
+
+        if (
+                on_delete == models.CASCADE
+                and issubclass(field.related_model, SoftDeleteModel)
+        ):
+            return field.related_model._soft_delete_queryset(
+                related_objects,
+                strict=strict,
+                transaction_id=transaction_id,
+                *args, **kwargs,
+            )
+
         for related_object in related_objects:
             count, counts_dict = self.__delete_related_object(
                 field, related_object, strict, transaction_id, *args, **kwargs
@@ -459,7 +823,9 @@ class SoftDeleteModel(models.Model):
     #             field, related_object, strict, *args, **kwargs
     #         )
 
-    def __restore_related_one_to_one(self, field, strict, transaction_id, *args, **kwargs):
+    def __restore_related_one_to_one(
+            self, field, strict, transaction_id, *args, **kwargs
+    ):
         """
         :param field: Field object representing the one-to-one relationship.
         :param strict: Flag indicating whether to raise an exception if the related object is not found.
@@ -474,7 +840,9 @@ class SoftDeleteModel(models.Model):
                 field, related_object, strict, transaction_id, *args, **kwargs
             )
 
-    def __restore_related_one_to_many(self, field, strict, transaction_id, *args, **kwargs):
+    def __restore_related_one_to_many(
+            self, field, strict, transaction_id, *args, **kwargs
+    ):
         """
         This method is used to restore related objects in a one-to-many relationship.
 
@@ -489,13 +857,14 @@ class SoftDeleteModel(models.Model):
         remote_model = field.remote_field.model
         if not issubclass(remote_model, SoftDeleteModel):
             raise ValueError('No related objects found')
-        # TODO: it would be better to save object manager names in the variables
-        for related_object in remote_model.deleted_objects.filter(
-            **{remote_field.name: self, "transaction_id": transaction_id}
-        ):
-            self.__restore_related_object(
-                field, related_object, strict, transaction_id, *args, **kwargs
-            )
+        remote_model._restore_queryset(
+            remote_model.deleted_objects.filter(
+                **{remote_field.name: self, "transaction_id": transaction_id}
+            ),
+            strict=strict,
+            transaction_id=transaction_id,
+            *args, **kwargs,
+        )
 
     # def __restore_related_many_to_many(self, field, strict, *args, **kwargs):
     #     """

--- a/django_softdelete/models.py
+++ b/django_softdelete/models.py
@@ -116,7 +116,7 @@ class SoftDeleteModel(models.Model):
         total_count = 0
         deleted_counts_dict = defaultdict(int)
 
-        with transaction.atomic():
+        with transaction.atomic(using=using, savepoint=False):
             for field in self._meta.get_fields():
 
                 # Skip generic relations
@@ -219,15 +219,18 @@ class SoftDeleteModel(models.Model):
         now = timezone.now()
 
         queryset = queryset.filter(deleted_at__isnull=True)
-        parent_ids = list(queryset.values_list("pk", flat=True))
+        objects_for_signals = list(queryset)
         if _visited is None:
             _visited = set()
-        node_ids = [
-            obj_id for obj_id in parent_ids if (cls._meta.label, obj_id) not in _visited
-        ]
-        for obj_id in node_ids:
+        filtered_objects = []
+        for obj in objects_for_signals:
+            obj_id = obj.pk
+            if (cls._meta.label, obj_id) in _visited:
+                continue
             _visited.add((cls._meta.label, obj_id))
-        parent_ids = node_ids
+            filtered_objects.append(obj)
+        objects_for_signals = filtered_objects
+        parent_ids = [obj.pk for obj in objects_for_signals]
         if not parent_ids:
             return 0, {}
         queryset = queryset.filter(pk__in=parent_ids)
@@ -280,9 +283,7 @@ class SoftDeleteModel(models.Model):
 
         total_count = 0
         deleted_counts_dict = defaultdict(int)
-        objects_for_signals = list(queryset)
-
-        with transaction.atomic():
+        with transaction.atomic(using=using, savepoint=False):
             for obj in objects_for_signals:
                 pre_delete.send(sender=cls, instance=obj, using=using)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,9 +2,11 @@ from collections import Counter
 from unittest.mock import patch
 
 import pytest
+from django.db import connection
 from django.db.models.deletion import ProtectedError
 from django.db.models.signals import pre_delete
 from django.db.models.signals import post_delete
+from django.test.utils import CaptureQueriesContext
 
 from django_softdelete.exceptions import SoftDeleteException
 from django_softdelete.signals import post_soft_delete
@@ -88,6 +90,11 @@ class TestSoftDeleteModel:
     def get_model_key(self, instance: SoftDeleteModel) -> str:
         """Returns the standard Django delete key 'app_label.model_name'."""
         return instance._meta.label
+
+    def get_query_count(self, operation):
+        with CaptureQueriesContext(connection) as captured:
+            operation()
+        return len(captured)
 
     # TESTS
 
@@ -211,6 +218,22 @@ class TestSoftDeleteModel:
         obj3.refresh_from_db()
         assert not obj3.is_deleted
 
+    def test_queryset_soft_delete_query_count_not_linear(self, product_factory):
+        small = [product_factory() for _ in range(2)]
+        large = [product_factory() for _ in range(20)]
+
+        small_ids = [obj.id for obj in small]
+        large_ids = [obj.id for obj in large]
+
+        small_query_count = self.get_query_count(
+            lambda: Product.objects.filter(id__in=small_ids).delete()
+        )
+        large_query_count = self.get_query_count(
+            lambda: Product.objects.filter(id__in=large_ids).delete()
+        )
+
+        assert (large_query_count - small_query_count) <= 4
+
     def test_queryset_hard_delete(self, product_factory):
         """
         Test the hard delete functionality of the queryset.
@@ -258,6 +281,25 @@ class TestSoftDeleteModel:
         assert obj3.is_deleted
         assert not obj3.is_restored
 
+    def test_queryset_restore_query_count_not_linear(self, product_factory):
+        small = [product_factory() for _ in range(2)]
+        large = [product_factory() for _ in range(20)]
+
+        small_ids = [obj.id for obj in small]
+        large_ids = [obj.id for obj in large]
+
+        Product.objects.filter(id__in=small_ids).delete()
+        Product.objects.filter(id__in=large_ids).delete()
+
+        small_query_count = self.get_query_count(
+            lambda: Product.deleted_objects.filter(id__in=small_ids).restore()
+        )
+        large_query_count = self.get_query_count(
+            lambda: Product.deleted_objects.filter(id__in=large_ids).restore()
+        )
+
+        assert (large_query_count - small_query_count) <= 4
+
     def test_delete_cascade(self, product_factory, option, product_landing, shop):
         """
         The test_delete_cascade method is responsible for testing the cascade
@@ -277,6 +319,20 @@ class TestSoftDeleteModel:
         # The model the product related to is still alive
         assert self.assert_object_in(shop, True, False, True)
         assert not shop.is_deleted
+
+    def test_delete_cascade_query_count_not_linear(self, product_factory):
+        small_product = product_factory()
+        large_product = product_factory()
+
+        for i in range(2):
+            Option.objects.create(product=small_product, name=f"small-{i}")
+        for i in range(20):
+            Option.objects.create(product=large_product, name=f"large-{i}")
+
+        small_query_count = self.get_query_count(lambda: small_product.delete())
+        large_query_count = self.get_query_count(lambda: large_product.delete())
+
+        assert (large_query_count - small_query_count) <= 4
 
     def test_restore_cascade(self, option, product_image):
         """
@@ -517,6 +573,41 @@ class TestSoftDeleteModel:
         assert obj1.is_deleted
         assert obj2.is_deleted
         assert self.assert_objects_count(Product, 0, 2, 2)
+
+    def test_queryset_soft_delete_uses_single_transaction_id(self, product_factory):
+        obj1 = product_factory()
+        obj2 = product_factory()
+
+        Product.objects.filter(id__in=[obj1.id, obj2.id]).delete()
+
+        obj1 = Product.global_objects.get(id=obj1.id)
+        obj2 = Product.global_objects.get(id=obj2.id)
+        assert obj1.transaction_id == obj2.transaction_id
+
+    def test_queryset_soft_delete_emits_per_instance_soft_delete_signal_by_default(
+            self, product_factory, signal_mock
+    ):
+        obj1 = product_factory()
+        obj2 = product_factory()
+        obj3 = product_factory()
+
+        with signal_mock(post_soft_delete, Product) as post_soft_delete_mock:
+            Product.objects.filter(id__in=[obj1.id, obj2.id, obj3.id]).delete()
+
+        assert post_soft_delete_mock.call_count == 3
+
+    def test_queryset_restore_emits_per_instance_restore_signal_by_default(
+            self, product_factory, signal_mock
+    ):
+        obj1 = product_factory()
+        obj2 = product_factory()
+        obj3 = product_factory()
+        Product.objects.filter(id__in=[obj1.id, obj2.id, obj3.id]).delete()
+
+        with signal_mock(post_restore, Product) as post_restore_mock:
+            Product.deleted_objects.filter(id__in=[obj1.id, obj2.id, obj3.id]).restore()
+
+        assert post_restore_mock.call_count == 3
 
     def test_queryset_hard_delete_returns_count(self, product_factory):
         obj1 = product_factory()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -234,6 +234,35 @@ class TestSoftDeleteModel:
 
         assert (large_query_count - small_query_count) <= 4
 
+    def test_queryset_soft_delete_avoids_pk_only_prefetch(self, product_factory):
+        product = product_factory()
+        Option.objects.create(product=product, name="o1")
+        Option.objects.create(product=product, name="o2")
+
+        with CaptureQueriesContext(connection) as captured:
+            Product.objects.filter(id=product.id).delete()
+
+        option_queries = [
+            q["sql"] for q in captured.captured_queries if '"test_app_option"' in q["sql"]
+        ]
+        assert not any(' AS "pk"' in sql for sql in option_queries)
+
+    def test_queryset_soft_delete_has_no_nested_savepoints(self, product_factory):
+        product = product_factory()
+        Option.objects.create(product=product, name="o1")
+        Option.objects.create(product=product, name="o2")
+
+        with CaptureQueriesContext(connection) as captured:
+            Product.objects.filter(id=product.id).delete()
+
+        savepoint_queries = [
+            q["sql"]
+            for q in captured.captured_queries
+            if q["sql"].startswith("SAVEPOINT")
+            or q["sql"].startswith("RELEASE SAVEPOINT")
+        ]
+        assert savepoint_queries == []
+
     def test_queryset_hard_delete(self, product_factory):
         """
         Test the hard delete functionality of the queryset.


### PR DESCRIPTION

   ## Summary
   This PR fixes N+1 query behavior in soft-delete/restore flows by replacing per-object iteration with bulk queryset operations while preserving soft-delete semantics and existing hard-delete behavior.
   May also be able to close https://github.com/san4ezy/django_softdelete/issues/34?

   ## Root cause
   `SoftDeleteQuerySet.delete()` and restore/cascade paths iterated row-by-row (`obj.delete()` / `obj.restore()`), generating per-row SELECT/UPDATE patterns that scale poorly (especially for large relation 
  clears/cascades).
   
   ## What changed
   - Added bulk soft-delete path in `SoftDeleteQuerySet.delete()` using `SoftDeleteModel._soft_delete_queryset(...)`
   - Added bulk restore path in `DeletedQuerySet.restore()` and `GlobalQuerySet.restore()` using `SoftDeleteModel._restore_queryset(...)`
   - Optimized one-to-many `CASCADE` soft-delete/restore for `SoftDeleteModel` relations to use queryset-based batching
   - Preserved correctness guarantees:
     - `deleted_at` set on delete
     - `restored_at` set on restore
     - `transaction_id` assigned consistently for bulk delete and used for transaction-scoped restore
   - Added recursion/cycle protection in recursive cascade traversal
   - Kept hard-delete behavior unchanged
   - Kept signal behavior compatible (per-instance soft-delete/restore signals still emitted)
   
   ## Why this is safe
   The change is internal to queryset/model delete/restore execution paths and keeps the same externally visible semantics for soft-delete state, restoration scope, and delete counters while reducing query volume.
   
   ## Tests
   Added/updated tests to verify:
   - Query count for queryset soft delete does not scale linearly with row count
   - Query count for cascade delete does not scale linearly with number of children
   - Query count for queryset restore does not scale linearly with row count
   - Bulk queryset delete uses a single transaction id across affected rows
   - Per-instance soft-delete/restore signal behavior remains intact
   