### PR TITLE
fix: make DO_NOTHING true no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - This CHANGELOG file to track project changes
+
+### Fixed
+
+- `on_delete=DO_NOTHING` is now a true no-op during a soft-delete cascade. The
+  unconditional `related_object.save()` at the tail of `__delete_related_object`
+  used to fire for every related object regardless of `on_delete`, mutating
+  `auto_now` fields and triggering save side-effects on objects the caller had
+  asked us not to touch. The trailing save was also a duplicate write for the
+  `SET_NULL` / `SET_DEFAULT` / `SET` branches, which already save inside their
+  own dispatch.

--- a/django_softdelete/models.py
+++ b/django_softdelete/models.py
@@ -307,11 +307,12 @@ class SoftDeleteModel(models.Model):
         else:  # M2M
             related_object.delete(strict=strict, *args, **kwargs)
 
-        try:
-            if related_object.pk is not None:
-                related_object.save()
-        except AttributeError:
-            pass
+        # Each branch above persists its own changes when needed (CASCADE
+        # recurses into delete(); SET_NULL/SET_DEFAULT/SET call save() after
+        # mutating the field; PROTECT/RESTRICT raise; DO_NOTHING is a no-op
+        # by contract). An unconditional save() here would either duplicate
+        # writes or, for DO_NOTHING, mutate auto_now fields and trigger save
+        # side-effects on objects that the caller asked us not to touch.
 
     def __restore_related_object(self, field, related_object, strict, transaction_id, *args, **kwargs):
         """

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -81,6 +81,12 @@ class Lead(SoftDeleteModel):
     name = models.CharField(max_length=32)
 
 
+class Note(SoftDeleteModel):
+    product = models.ForeignKey(Product, on_delete=models.DO_NOTHING, null=True)
+    name = models.CharField(max_length=32)
+    edited_at = models.DateTimeField(auto_now=True)
+
+
 class ProductNotSoftRelations(ProductAbstract):
     pass  # related to NotSoftRelatedModel with a revers relation
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,11 @@ def lead(name, product):
 
 
 @pytest.fixture
+def note(name, product):
+    return Note.objects.create(name=name, product=product)
+
+
+@pytest.fixture
 def product_image(name, product):
     return ProductImage.objects.create(name=name)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -421,6 +421,32 @@ class TestSoftDeleteModel:
         assert not another_product.is_deleted
         assert not another_option.is_deleted
 
+    def test_do_nothing_does_not_save_related(self, note):
+        """
+        on_delete=DO_NOTHING must be a true no-op: the related object's
+        save() must not be called when the parent is soft-deleted, otherwise
+        auto_now fields and save-side-effects fire spuriously.
+        """
+        product = note.product
+        initial_edited_at = note.edited_at
+
+        product.delete()
+
+        note.refresh_from_db()
+        assert note.edited_at == initial_edited_at
+        assert not note.is_deleted
+
+    def test_do_nothing_does_not_call_save_on_related(self, note):
+        """
+        Asserts directly that save() is not invoked on a DO_NOTHING-related
+        object during a soft-delete cascade walk.
+        """
+        product = note.product
+
+        with patch.object(Note, "save", autospec=True) as mock_save:
+            product.delete()
+            assert mock_save.call_count == 0
+
     def test_soft_delete_m2m(self, product, product_image_factory):
         image1 = product_image_factory()
         image2 = product_image_factory()


### PR DESCRIPTION
## Summary

 `on_delete=DO_NOTHING` is documented as a no-op, but during a soft-delete cascade walk the related object is silently saved anyway. The unconditional `related_object.save()` at the tail of
 `SoftDeleteModel.__delete_related_object` runs for every branch — it bumps `auto_now` fields, fires `pre_save`/`post_save` signals, and triggers any custom `save()` side-effects on objects the caller asked us not
   to touch.

  It is also a duplicate write for `SET_NULL`, `SET_DEFAULT`, and `SET`, which each already call `related_object.save()` inside their own branch.

  ## The fix

  Drop the trailing `try/save()/except AttributeError` block at the end of `__delete_related_object`. Each branch is now responsible for its own persistence:

  - `CASCADE` — recurses into `delete()`
  - `SET_NULL` / `SET_DEFAULT` / `SET` — already save after mutating the field
  - `PROTECT` / `RESTRICT` — raise
  - `DO_NOTHING` — true no-op (was: still saved)

  ## Repro / regression coverage

  Added a `Note` model in `test_app` with an `on_delete=DO_NOTHING` FK and an `auto_now=True` `edited_at`, plus two tests in `tests/test_models.py`:

  - `test_do_nothing_does_not_save_related` — soft-deleting the parent must not bump the child's `edited_at`
  - `test_do_nothing_does_not_call_save_on_related` — patches `Note.save` and asserts `call_count == 0` during the cascade
